### PR TITLE
Set the default codec to JSON

### DIFF
--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -6,7 +6,7 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
   config_name 'kafka'
   milestone 1
 
-  default :codec, 'plain'
+  default :codec, 'json'
 
   config :zk_connect, :validate => :string, :default => 'localhost:2181'
   config :group_id, :validate => :string, :default => 'logstash'

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -6,7 +6,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config_name 'kafka'
   milestone 1
 
-  default :codec, 'plain'
+  default :codec, 'json'
 
   config :broker_list, :validate => :string, :default => 'localhost:9092'
   config :topic_id, :validate => :string, :default => 'test'


### PR DESCRIPTION
Sending structured messages is oh so nice! The JSON codec
sends a JSON representation of the Logstash event on output
and parses it on input. This allows you to more easily
send data between Logstash agents using Kafka as well as
easier integration with tools sending and receiving events
from Logstash over Kafka!
