### PR TITLE
Support for Kafka partition keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See http://kafka.apache.org/documentation.html#producerconfigs for details about
             partitioner_class => ... # string (optional) default: "kafka.producer.DefaultPartitioner"
             request_timeout_ms => ... # number (optional) default: 10000
             producer_type => ... # string (optional), one of ["sync", "async"] default => 'sync'
-            key_serializer_class => ... # string (optional) default: nil
+            key_serializer_class => ... # string (optional) default: "kafka.serializer.StringEncoder"
             message_send_max_retries => ... # number (optional) default: 3
             retry_backoff_ms => ... # number (optional) default: 100
             topic_metadata_refresh_interval_ms => ... # number (optional) default: 600 * 1000
@@ -116,7 +116,14 @@ the output configuration something like:
             }
         }
     }
-    
+
+To specify a parition key for Kafka, you can configure format that will produce the key as a string.  For example, to parition by host:
+
+    # output {
+        kafka {
+            key_format => "%{host}"
+        }
+    }
 ## Manual Install
 
 Those who wish to use this plugin in an existing Logstash 1.4.0+ installation can follow these instructions to integrate the plugin into their Logstash system.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ To specify a parition key for Kafka, configure a format that will produce the ke
 
     # output {
         kafka {
-            key_format => "%{host}"
+            partition_key_format => "%{host}"
         }
     }
 ## Manual Install

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ the output configuration something like:
         }
     }
 
-To specify a parition key for Kafka, you can configure format that will produce the key as a string.  For example, to parition by host:
+To specify a parition key for Kafka, configure a format that will produce the key as a string.  For example, to parition by host:
 
     # output {
         kafka {

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -27,7 +27,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config :send_buffer_bytes, :validate => :number, :default => 100 * 1024
   config :client_id, :validate => :string, :default => ""
   
-  config :key_format, :validate => :string, :default => nil
+  config :partition_key_format, :validate => :string, :default => nil
 
   public
   def register
@@ -56,7 +56,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       :batch_num_messages => @batch_num_messages,
       :send_buffer_bytes => @send_buffer_bytes,
       :client_id => @client_id,
-      :key_format => @key_format
+      :partition_key_format => @partition_key_format
     }
     @producer = Kafka::Producer.new(options)
     @producer.connect()
@@ -65,7 +65,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
     @codec.on_event do |event|
       begin
-        @producer.sendMsg(@topic_id, @key, event)
+        @producer.sendMsg(@topic_id, @partition_key, event)
       rescue LogStash::ShutdownSignal
         @logger.info('Kafka producer got shutdown signal')
       rescue => e
@@ -81,9 +81,9 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       finished
       return
     end
-    @key = if @key_format.nil? then nil else event.sprintf(@key_format) end
+    @partition_key = if @partition_key_format.nil? then nil else event.sprintf(@partition_key_format) end
     @codec.encode(event)
-    @key = nil
+    @partition_key = nil
   end
 
 end #class LogStash::Outputs::Kafka


### PR DESCRIPTION
Provides a way to specify a partition key as a string.  Defaults key_serializer to kafka.serializer.StringEncoder to match.

Here's how you configure it to partition message by host:

```
output {
    kafka {
        partition_key_format => "%{host}"
    }
}
```
