### PR TITLE
Added possibility to append kafka keys to events

### DIFF
--- a/spec/inputs/kafka.rb
+++ b/spec/inputs/kafka.rb
@@ -42,7 +42,7 @@ describe LogStash::Inputs::Kafka do
     class Kafka::Group
       public
       def run(a_numThreads, a_queue)
-        a_queue << "Kafka message"
+        a_queue << OpenStruct.new(:message => "Kafka message")
       end
     end
 


### PR DESCRIPTION
This is related to: https://github.com/joekiller/logstash-kafka/issues/38 and pull request: https://github.com/joekiller/jruby-kafka/pull/12

By the way. I had problems with access to kafka fields (decorated events). They weren't accessible in ie. grok and elasticsearch output had problem with serializing them into json. This seems to be similar to problem with twitter input: https://github.com/elasticsearch/logstash/issues/1471. To make it work i had to apply this commit: https://github.com/jpodeszwik/logstash-kafka/commit/1e71b39b49fc3fd3d47bd1eea966e41005f3b978 (not included in this pull request). Should i also include it here?