### PR TITLE
Add message key to distribute payloads among distinct partitions

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -1,3 +1,4 @@
+require 'zlib'
 require 'logstash/namespace'
 require 'logstash/outputs/base'
 
@@ -136,7 +137,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
     @codec.on_event do |event|
       begin
-        @producer.send_msg(@topic_id,nil,event)
+        @producer.send_msg(@topic_id, Zlib::crc32(event).to_s, event)
       rescue LogStash::ShutdownSignal
         @logger.info('Kafka producer got shutdown signal')
       rescue => e


### PR DESCRIPTION
Problem:
Having nil prevented kafka to send messages to different partitions. (nil will be of no use for the partition function, ie: kafka.producer.DefaultPartitioner)

Zlib::crc32(event) uses 250ns aprox. and 'zlib' is part of the standard library, so no dependencies to load.

Reference:
http://programmers.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
